### PR TITLE
fix how offset/factor per level is handled and displayed

### DIFF
--- a/1.5/Source/VSE/Expertise/ExpertiseDef.cs
+++ b/1.5/Source/VSE/Expertise/ExpertiseDef.cs
@@ -54,8 +54,8 @@ public class ExpertiseDef : Def
             statFactors.Aggregate("",
                 (current, factor) =>
                     current +
-                    $"\n{prefix}{factor.stat.LabelCap}: {factor.stat.Worker.ValueToString(factor.value * (level + 1), false, ToStringNumberSense.Factor)}"),
+                    $"\n{prefix}{factor.stat.LabelCap}: {factor.stat.Worker.ValueToString(1 + factor.value * level, false, ToStringNumberSense.Factor)}"),
             (current, offset) =>
                 current +
-                $"\n{prefix}{offset.stat.LabelCap}: {offset.stat.Worker.ValueToString(offset.value * (level + 1), false, ToStringNumberSense.Offset)}");
+                $"\n{prefix}{offset.stat.LabelCap}: {offset.stat.Worker.ValueToString(offset.value * level, false, ToStringNumberSense.Offset)}");
 }

--- a/1.5/Source/VSE/Expertise/ExpertisePatches.cs
+++ b/1.5/Source/VSE/Expertise/ExpertisePatches.cs
@@ -169,7 +169,7 @@ public static class ExpertisePatches
         var idx1 = FindIfJumpIndex(codes, 0, info);
         var label = RewriteJump(codes, generator, 0, AccessTools.Field(typeof(StatDef), nameof(StatDef.skillNeedOffsets)));
         if (label is null) throw new("Failed to find jump location");
-        codes.InsertRange(idx1, new[]
+        codes.InsertRange(idx1 - 1, new[]
         {
             new CodeInstruction(OpCodes.Ldloc_2).WithLabels(label.Value),
             CodeInstruction.Call(typeof(ExpertiseTrackers), nameof(ExpertiseTrackers.Expertise), new[] { typeof(Pawn) }),
@@ -181,7 +181,7 @@ public static class ExpertisePatches
         var idx2 = FindIfJumpIndex(codes, idx1, info);
         label = RewriteJump(codes, generator, idx1, AccessTools.Field(typeof(StatDef), nameof(StatDef.skillNeedFactors)));
         if (label is null) throw new("Failed to find jump location");
-        codes.InsertRange(idx2, new[]
+        codes.InsertRange(idx2 - 1, new[]
         {
             new CodeInstruction(OpCodes.Ldloc_2).WithLabels(label.Value),
             CodeInstruction.Call(typeof(ExpertiseTrackers), nameof(ExpertiseTrackers.Expertise), new[] { typeof(Pawn) }),

--- a/1.5/Source/VSE/Expertise/ExpertiseRecord.cs
+++ b/1.5/Source/VSE/Expertise/ExpertiseRecord.cs
@@ -26,6 +26,7 @@ public class ExpertiseRecord : IExposable
     {
         Pawn = pawn;
         this.def = def;
+        this.XpRequiredForLevelUp = SkillRecord.XpRequiredToLevelUpFrom(0);
     }
 
     public float XpTotalEarned
@@ -43,7 +44,6 @@ public class ExpertiseRecord : IExposable
     public Pawn Pawn { get; }
 
     public int Level => level;
-    public int LevelPlusOne => level + 1;
 
     public string LevelDescriptor => level is < 0 or > 20 ? "Unknown".Translate() : $"VSE.Expertise{level}".Translate();
 

--- a/1.5/Source/VSE/Expertise/ExpertiseTracker.cs
+++ b/1.5/Source/VSE/Expertise/ExpertiseTracker.cs
@@ -39,7 +39,7 @@ public class ExpertiseTracker : IExposable
         for (var i = 0; i < expertise.Count; i++)
         {
             var expertiseRecord = expertise[i];
-            value += expertiseRecord.def.statOffsets.GetStatOffsetFromList(stat) * expertiseRecord.LevelPlusOne;
+            value += expertiseRecord.def.statOffsets.GetStatOffsetFromList(stat) * expertiseRecord.Level;
         }
     }
 
@@ -54,7 +54,7 @@ public class ExpertiseTracker : IExposable
             if (offset != 0f)
             {
                 builder.AppendLine(
-                    $"  {expertiseRecord.def.LabelCap} ({expertiseRecord.Level}): {stat.Worker.ValueToString(offset * expertiseRecord.LevelPlusOne, false, ToStringNumberSense.Offset)}");
+                    $"  {expertiseRecord.def.LabelCap} ({expertiseRecord.Level}): {stat.Worker.ValueToString(offset * expertiseRecord.Level, false, ToStringNumberSense.Offset)}");
                 addedAnything = true;
             }
         }
@@ -69,11 +69,11 @@ public class ExpertiseTracker : IExposable
         for (var i = 0; i < expertise.Count; i++)
         {
             var expertiseRecord = expertise[i];
-            var offset = expertiseRecord.def.statFactors.GetStatFactorFromList(stat);
-            if (offset != 1f)
+            var factorOffset = expertiseRecord.def.statFactors.GetStatValueFromList(stat, 0f);
+            if (factorOffset != 0f)
             {
                 builder.AppendLine(
-                    $"  {expertiseRecord.def.LabelCap} ({expertiseRecord.Level}): {stat.Worker.ValueToString(offset * expertiseRecord.LevelPlusOne, false, ToStringNumberSense.Factor)}");
+                    $"  {expertiseRecord.def.LabelCap} ({expertiseRecord.Level}): {stat.Worker.ValueToString(1f + factorOffset * expertiseRecord.Level, false, ToStringNumberSense.Factor)}");
                 addedAnything = true;
             }
         }
@@ -86,8 +86,8 @@ public class ExpertiseTracker : IExposable
         for (var i = 0; i < expertise.Count; i++)
         {
             var expertiseRecord = expertise[i];
-            var factor = expertiseRecord.def.statFactors.GetStatFactorFromList(stat);
-            if (factor != 1f) value *= factor * expertiseRecord.LevelPlusOne;
+            var factor = expertiseRecord.def.statFactors.GetStatValueFromList(stat, 0f);
+            if (factor != 0f) value *= 1f + factor * expertiseRecord.Level;
         }
     }
 }

--- a/1.5/Source/VSE/Expertise/ExpertiseUIUtility.cs
+++ b/1.5/Source/VSE/Expertise/ExpertiseUIUtility.cs
@@ -117,7 +117,7 @@ public static class ExpertiseUIUtility
                 GUI.color = Color.white;
             }
 
-            TooltipHandler.TipRegion(buttonRect, expertise.description + "\n\n" + "VSE.Effects.PerLevel".Translate() + expertise.Effects(0, "  - "));
+            TooltipHandler.TipRegion(buttonRect, expertise.description + "\n\n" + "VSE.Effects.PerLevel".Translate() + expertise.Effects(1, "  - "));
             y += 60f;
         }
 


### PR DESCRIPTION
- Expertise starts granting stat bonuses at level 1 instead of level 0. 
   - Now expertise that grant 5% bonuses per level will be a nice round +100% at level 20 instead of the odd +105%.
- Actually require XP gain to rise from level 0 to level 1 in an expertise. 
   - Currently requires 0 XP meaning you level up the moment you perform a job with that skill.
- Changed how statFactors in ExpertiseDef are handled; they are now effectively an offset from 100%
   - For example an expertise that grants a statFactor of 0.05 per level would multiply that stat by 1.5 (150%) at level 10
   - Conversely if the statFactor were -0.05 per level then at level 10 the stat would be multiplied by 0.5 (50%)
   - This will have no immediate effect since statFactors isn't used for any of the existing expertise
- Fixed indexes in StatExplainTranspiler which caused the effects of expertise to not always be included in explanation when the stat is viewed from a pawn's info panel
   - The transpiler was inserting instructions in the wrong location, but depending on other factors affecting that stat it would still be displayed most of the time
   - When viewed in Transpiler Explorer you can see the current version has a jump that can cause the method call we're inserting to be skipped over.

Current Transpiler Result
![image](https://github.com/user-attachments/assets/1c3e32a2-f4a2-4206-aeda-32012cb39b1a)

Fixed Transpiler Result
![image](https://github.com/user-attachments/assets/760ed427-d062-47fd-b767-1ffdf40a352c)
