### PR TITLE
change statOffset for sharpshooting to make it effective

### DIFF
--- a/1.5/Defs/ExpertiseDefs/Expertise.xml
+++ b/1.5/Defs/ExpertiseDefs/Expertise.xml
@@ -6,7 +6,7 @@
     <description>An expertise in accuracy when firing both high-tech and low-tech ranged weapons.</description>
     <skill>Shooting</skill>
     <statOffsets>
-      <ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
+      <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
     </statOffsets>
   </VSE.Expertise.ExpertiseDef>
   <VSE.Expertise.ExpertiseDef>


### PR DESCRIPTION
- Changed statOffset for ShootingAccuracyPawn from 0.05 to 1
- This stat works on a post process curve based on shooting skill level, not a base value percentage.
- An offset of 0.05 per level means that at Sharpshooting lvl 20 you would have a bonus equivalent to a single level of Shooting
- The base accuracy after the post process curve is applied would only increase from 0.99 to 0.99125
- With this change the base accuracy increases from 0.99 to 0.999 at Sharpshooting lvl 20, which becomes a noticeable improvement at long range.
- Concrete examples of base accuracy at range of 40 cells:
```
 Shooting 20 - No Expertise - Vanilla Calculation - 0.99^40    = 0.66897 (~66.9% accuracy)
 Shooting 20 - Sharpshooting 20 - Offset of 0.05  - 0.99125^40 = 0.70360 (~70.4% accuracy)
 Shooting 20 - Sharpshooting 20 - Offset of 1.00  - 0.999^40   = 0.96077 (~96.1% accuracy)
```