### PR TITLE
fix GetSkillDescription_Transpiler 

### DIFF
--- a/1.5/Source/VSE/Passions/PassionPatches.cs
+++ b/1.5/Source/VSE/Passions/PassionPatches.cs
@@ -261,14 +261,12 @@ public static class PassionPatches
             CodeInstruction.Call(typeof(PassionPatches), nameof(AddForgetRateInfo))
         });
 
-        var info1 = AccessTools.Field(typeof(StatDefOf), nameof(StatDefOf.AnimalsLearningFactor));
-        var idx3 = codes.FindLastIndex(ins => ins.LoadsField(info1));
-        var idx5 = codes.FindIndex(idx3, ins => ins.opcode == OpCodes.Ldarg_0);
-        labels = codes[idx5].labels.ListFullCopy();
-        codes[idx5].labels.Clear();
-        codes.InsertRange(idx5, new[]
+        var info1 = AccessTools.Method(typeof(SkillUI), nameof(SkillUI.GetLearningFactor));
+        var idx3 = codes.FindLastIndex(ins => ins.Calls(info1));
+        var idx5 = codes.FindIndex(idx3, ins => ins.opcode == OpCodes.Pop);
+        codes.InsertRange(idx5 + 1, new[]
         {
-            new CodeInstruction(OpCodes.Ldarg_0).WithLabels(labels),
+            new CodeInstruction(OpCodes.Ldarg_0),
             new CodeInstruction(OpCodes.Ldloc_0),
             CodeInstruction.Call(typeof(PassionPatches), nameof(AddLearnRateOtherInfo))
         });


### PR DESCRIPTION
Fixes GetSkillDescription_Transpiler so that the learning rate malus applied by having a Critical passion is always shown.

The current implementation of the transpiler places the call to `PassionPatches.AddLearnRateOtherInfo` inside of an `if` block so that it is only called when the pawn's `GlobalLearningFactor` is a value other than `1f`. This can be seen in the following screenshot from Transpiler Explorer.

![image](https://github.com/user-attachments/assets/513e0647-7e70-4741-b450-deba45ecfd41)

I repositioned this call just below the line which appends the skill passion's learning factor to the description.

![image](https://github.com/user-attachments/assets/5f77da5b-1ba5-4690-83f1-395dff973486)

